### PR TITLE
Fix for hint table on challenge view page

### DIFF
--- a/templates/scoreboard/chall.html
+++ b/templates/scoreboard/chall.html
@@ -63,6 +63,7 @@
 			<table class="table sortable">
 					<thead>
 						<td>Challenge ID</td>
+						<td>Challenge Title</td>
 						<td>Hint</td>
 						<td>Cost</td>
 						<td>Hint Purchaser</td>
@@ -74,6 +75,7 @@
 							<td>{{hint[1]}}</td>
 							<td>{{hint[2]}}</td>
 							<td>{{hint[3]}}</td>
+							<td>{{hint[4]}}</td>
 						</tr>
 					{% endfor %}
 				</tbody>


### PR DESCRIPTION
Fix for hint table on challenge view page. Previously, was showing like the following where Hint Purchaser was showing the cost value and cost was the flag value, etc.

![image](https://github.com/ShyftXero/byoctf_discord/assets/8397647/0974d8e4-c838-44de-8462-4cc03a35de01)
