### PR TITLE
Permission check for scoreboard.py

### DIFF
--- a/scoreboard.py
+++ b/scoreboard.py
@@ -381,7 +381,9 @@ def grant_points():
     admin_user = db.get_user_by_api_key(api_key)
     if admin_user == None:
         return "invalid admin api key", 403
-
+    if admin_user == None:
+        return "user is not an admin", 403
+    
     # seems legit...
     res = db.grant_points(
         requested_user=target_user, admin_user=admin_user, amount=points, msg=message


### PR DESCRIPTION
Adds a needed permission check to the `/api/grant_points` endpoint to validate a user is an administrator before granting points. While participating in a recent CTF, we discovered that we could arbitrarily give ourselves points - so we did.

```http
POST /api/grant_points HTTP/1.1
Host: scoreboard.ctf.REDACTED.com
Cookie: api_key=REDACTED
Content-Type: application/x-www-form-urlencoded
Connection: close
Content-Length: 93

target_user=zzgoon&points=31337&message=:)&admin_api_key=REDACTED
```

```http
HTTP/1.1 200 OK
Server: nginx/1.22.1
Date: Sun, 21 Apr 2024 00:02:38 GMT
Content-Type: application/json
Content-Length: 147
Connection: close
Access-Control-Allow-Origin: *

{"orig_request":{"admin_api_key":"REDACTED","message":":)","points":"31337","target_user":"zzgoon"},"status":"sucess"}
```
![image](https://github.com/ShyftXero/byoctf_discord/assets/43768871/0a33271e-bea1-4ca2-89c0-17cba2b21f94)


![image](https://github.com/ShyftXero/byoctf_discord/assets/43768871/af38d169-2cd1-47f7-b0a6-e334e5e724e1)
