### PR TITLE
Update ctrl_ctf.py - bulk_add_chall

### DIFF
--- a/ctrl_ctf.py
+++ b/ctrl_ctf.py
@@ -780,7 +780,7 @@ class Commands:
 
         return valid_toml_files
 
-    def bulk_add_chall(self, start_path: str = ".", byoc: bool = False):
+    def bulk_add_chall(self, start_path: str = ".", byoc: bool = True):
         chall_files = self._find_chall_files(start_path)
         for chall in chall_files:
             self.add_chall(chall, byoc=byoc, bypass_cost=True)


### PR DESCRIPTION
I feel like in most cases with this helper command to bulk load challenges you'll always want byoc to default to "true" since we're bypassing "cost". We are using this to bulk load "core" challenges for our upcoming event. I might be missing additional use cases so feel free to disagree and discard. Just thought I would pass it along just in case. :)